### PR TITLE
Remove may_sync and add BlockAndRetry

### DIFF
--- a/lib/Channel.ml
+++ b/lib/Channel.ml
@@ -56,7 +56,6 @@ module Make (Sched : Scheduler.S) : S with
     let rec complete_exchange : 'd. (a,'d) t -> (c,'d) t =
       fun receiver_k ->
         { always_commits = false;
-          may_sync = receiver_k.may_sync;
           compose = (fun next -> complete_exchange (receiver_k.compose next));
           try_react = try_react payload sender_offer sender_rx receiver_k}
     in
@@ -113,7 +112,6 @@ module Make (Sched : Scheduler.S) : S with
     in
     fun ep k ->
       { always_commits = false;
-        may_sync = true;
         compose = (fun next -> swap ep (k.compose next));
         try_react = try_react ep k}
 

--- a/lib/Channel.ml
+++ b/lib/Channel.ml
@@ -82,7 +82,7 @@ module Make (Sched : Scheduler.S) : S with
       (* Search for matching offers *)
       let rec try_from cursor retry =
         match MSQueue.next cursor with
-        | None -> if (retry) then Retry else Block
+        | None -> if retry then Retry else Block
         | Some (Message (sender_offer,exchange), cursor) ->
             let same_offer o = function
             | None -> false
@@ -97,7 +97,7 @@ module Make (Sched : Scheduler.S) : S with
                 let merged = exchange.compose k in
                 match merged.try_react a new_rx offer with
                 | Retry -> try_from cursor true
-                | Block -> try_from cursor retry
+                | Block | BlockAndRetry -> try_from cursor retry
                 | v -> v )
       in
       ( begin

--- a/lib/Reagent.mli
+++ b/lib/Reagent.mli
@@ -19,12 +19,11 @@ module type S = sig
 
   type reaction
   type 'a offer
-  type 'a result = Block | Retry | Done of 'a
+  type 'a result = BlockAndRetry | Block | Retry | Done of 'a
   type ('a,'b) t =
     { try_react : 'a -> reaction -> 'b offer option -> 'b result;
       compose : 'r. ('b,'r) t -> ('a,'r) t;
-      always_commits : bool;
-      may_sync : bool }
+      always_commits : bool }
 
   val never       : ('a,'b) t
   val constant    : 'a -> ('b,'a) t

--- a/lib/Ref.ml
+++ b/lib/Ref.ml
@@ -58,7 +58,6 @@ module Make(Sched: Scheduler.S)
         k.try_react v rx o
       in
         { always_commits = k.always_commits;
-          may_sync = k.may_sync;
           compose = (fun next -> read r (k.compose next));
           try_react }
 
@@ -85,7 +84,6 @@ module Make(Sched: Scheduler.S)
     in
     fun r expect update k ->
       { always_commits = false;
-        may_sync = k.may_sync;
         compose = (fun next -> cas r expect update (k.compose next));
         try_react = try_react r expect update k}
 
@@ -118,7 +116,6 @@ module Make(Sched: Scheduler.S)
     in
     fun r f k ->
       { always_commits = false;
-        may_sync = k.may_sync;
         compose = (fun next -> upd r f (k.compose next));
         try_react = try_react r f k}
 

--- a/test/stack_test.ml
+++ b/test/stack_test.ml
@@ -121,18 +121,47 @@ end
 
 module Data = Reagents_data.Make(Reagents)
 
-let main () =
-  let module M = Test(Lock_stack) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Lock stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
+module Channel_stack : STACK = struct
+  module TS = Treiber_stack.Make(Reagents)
+  module C = Reagents.Channel
+  open Reagents
 
+  type 'a t =
+    {stack     : 'a TS.t;
+     elim_push : ('a,unit) C.endpoint;
+     elim_pop  : (unit,'a) C.endpoint}
+
+  let create () =
+    let (elim_push, elim_pop) = C.mk_chan () in
+    { stack = TS.create (); elim_push; elim_pop }
+
+  let push q v =
+    let r = C.swap q.elim_push <+> TS.push q.stack in
+    Reagents.run r v
+
+  let pop q =
+    let side_chan = C.swap q.elim_pop >>= (fun x -> constant (Some x)) in
+    let r = side_chan <+> TS.try_pop q.stack in
+    Reagents.run r ()
+
+end
+
+let main () =
   let module M = Test(MakeS(Data.Treiber_stack)) in
   let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
   printf "Treiber stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
 
+  let module M = Test(Lock_stack) in
+  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Lock stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
+
   let module M = Test(MakeS(Data.Elimination_stack)) in
   let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Elimination stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m)
+  printf "Elimination stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
+
+  let module M = Test(Channel_stack) in
+  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Channel-based stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m)
 
 let () = S.run main
 let () = Unix.sleep 1


### PR DESCRIPTION
Simplify Reagent type record by removing `may_sync`. This should lead to performance improvement in the case where a protocol performing channel communication only transitively fails. Earlier, during retry in that case, an offer would be created. Now, an offer will only be created if at least one branch of the protocol permanently fails. 