### PR TITLE
Fix deadlocking philosophers and related bugs

### DIFF
--- a/test/dining_philosophers.ml
+++ b/test/dining_philosophers.ml
@@ -58,9 +58,7 @@ let eat l_fork r_fork i j =
   ignore @@ run (take l_fork <*> take r_fork) ();
   printf "Philosopher %d eating in round %d\n%!" i j;
   S.fork @@ run (drop l_fork);
-  if j == num_rounds
-  then S.fork @@ run (drop r_fork)
-  else run (drop r_fork) ()
+  S.fork @@ run (drop r_fork)
 
 let main () =
   let b = CDL.create num_philosophers in


### PR DESCRIPTION
My attempt to fix #10 and two related bugs.

Note that the first commit in this PR essentially reverts #5. I'm not sure whether I understand the optimizations implemented there correctly, but even without them the kCAS operation should be lock-free: If multiple threads attempt an overlapping kCAS, then the one that is able to complete the shared CAS with the largest id will win the race and complete its kCAS operation successfully. This would imply that there is always some thread that makes progress, but I'm not sure whether my reasoning here is correct...

The second commit fixes a simple oversight. The last one mostly reverts a21f738c24a81d6a8de9484ae0ba7fa868887c91 and fixes the actual deadlock. I don't know if it's possible to keep the blocking behavior introduced by the mentioned commit without risking a deadlock. It seems to me that a deadlock can only be avoided if the "fastest" philosopher is at most 1 round ahead, which presumably requires some additional synchronization.
