### PR TITLE
Add continuous integration with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: c
+sudo: required
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-ocaml.sh
+  - bash -ex .travis-ocaml.sh
+  - opam remote add multicore https://github.com/ocamllabs/multicore-opam.git
+  - opam switch 4.02.2+multicore
+  - eval `opam config env`
+  # TODO: Replace this with opam install . --deps-only when OPAM v2 becomes stable.
+  - opam pin add reagents . -n
+  - opam install -y --deps-only reagents
+script:
+  - eval `opam config env`
+  - make all
+env:
+  global:
+    - OCAML_VERSION=4.02
+os:
+  - linux


### PR DESCRIPTION
This pull adds continuous integration with Travis, which will help to ensure that the repository builds correctly.

Note that in order to get automatic build validation on GitHub, Travis CI would have to be enabled at https://travis-ci.org.