### PR TITLE
Add jbuilder dependency to reagents package

### DIFF
--- a/reagents.opam
+++ b/reagents.opam
@@ -13,6 +13,7 @@ available: [ ocaml-version >= "4.02.2"]
 depends: [
 	"lockfree" {>= "0.1.0"}
 	"kcas" {>= "0.1.2"}
+	"jbuilder" {>= "1.0+beta16"}
 ]
 
 depopts: []


### PR DESCRIPTION
Currently, `opam install reagents` fails since jbuilder is needed to build the package.  This pull adds jbuilder to the dependencies so that `opam install reagents` will work from a fresh opam install.