### PR TITLE
Timeouts in tests

### DIFF
--- a/tests/catalyst_test.ml
+++ b/tests/catalyst_test.ml
@@ -23,7 +23,7 @@ let message_counter () =
       assert_counter 2)
 
 let three_channels_joined () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let transferred = Atomic.make 0 in
 
       let (a1 : (int, unit) Channel.endpoint), a2 = Channel.mk_chan () in
@@ -50,7 +50,7 @@ let three_channels_joined () =
       ())
 
 let message_counter_stress () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let receiver_counter = Atomic.make 0 in
       let assert_counter v = assert (Atomic.get receiver_counter == v) in
 

--- a/tests/catalyst_test.ml
+++ b/tests/catalyst_test.ml
@@ -4,7 +4,7 @@ module Counter = Reagents.Data.Counter
 open Reagents
 
 let message_counter () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let receiver_counter = Atomic.make 0 in
       let assert_counter v = assert (Atomic.get receiver_counter == v) in
 

--- a/tests/counter_test.ml
+++ b/tests/counter_test.ml
@@ -20,7 +20,7 @@ open Reagents
 module Counter = Data.Counter
 
 let counter () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let c = Counter.create 0 in
       assert (run (Counter.get c) () == 0);
       assert (run (Counter.inc c) () == 0);
@@ -29,7 +29,7 @@ let counter () =
       assert (run (Counter.get c) () == 1))
 
 let counter_await_value () =
-  Scheduler.run_allow_deadlock (fun () ->
+  Scheduler.run_allow_deadlock ~timeout:`Default (fun () ->
       let c = Counter.create 0 in
       assert (run (Counter.inc c) () == 0);
       run

--- a/tests/eli_stack.ml
+++ b/tests/eli_stack.ml
@@ -19,8 +19,8 @@ let num_items = 1_000_000
 let items_per_dom = num_items / num_doms
 let () = Printf.printf "items_per_domain = %d\n%!" items_per_dom
 
-module S = (val Sched_ws.make num_doms ())
-module Reagents = Reagents.Make (S)
+module Scheduler = (val Sched_ws.make num_doms ())
+module Reagents = Reagents.Make (Scheduler)
 open Reagents
 
 module type STACK = sig
@@ -91,7 +91,7 @@ module Test (Q : STACK) = struct
       | Some _ -> consume (i + 1)
     in
     for _ = 1 to num_doms - 1 do
-      S.fork (fun () ->
+      Scheduler.fork (fun () ->
           produce items_per_domain;
           consume 0;
           run (CDL.count_down b) ())
@@ -110,4 +110,4 @@ let main () =
   Printf.printf "Elimination stack: mean = %f, sd = %f tp=%f\n%!" m sd
     (float_of_int num_items /. m)
 
-let () = S.run main
+let () = Scheduler.run ~timeout:`Default main

--- a/tests/hw_queue.ml
+++ b/tests/hw_queue.ml
@@ -18,8 +18,8 @@ let num_doms = 4
 let num_items = 1_000_000
 let items_per_dom = num_items / num_doms
 
-module S = (val Sched_ws.make num_doms ())
-module Reagents = Reagents.Make (S)
+module Scheduler = (val Sched_ws.make num_doms ())
+module Reagents = Reagents.Make (Scheduler)
 open Reagents
 
 module type QUEUE = sig
@@ -88,7 +88,7 @@ module Test (Q : QUEUE) = struct
       | Some _ -> consume (i + 1)
     in
     for _ = 1 to num_doms - 1 do
-      S.fork (fun () ->
+      Scheduler.fork (fun () ->
           produce items_per_domain;
           consume 0;
           run (CDL.count_down b) ())
@@ -106,4 +106,4 @@ let main () =
     sd
     (float_of_int num_items /. m)
 
-let () = S.run main
+let () = Scheduler.run ~timeout:`Default main

--- a/tests/lock_test.ml
+++ b/tests/lock_test.ml
@@ -21,7 +21,7 @@ module Lock = Sync.Lock
 module CV = Sync.Condition_variable
 
 let test () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let l = Lock.create () in
       let cv = CV.create () in
       run (Lock.acq l) ();

--- a/tests/pair_not_parallel.ml
+++ b/tests/pair_not_parallel.ml
@@ -22,7 +22,7 @@ let work sw v () =
   Printf.printf "%d" x
 
 let two_way () =
-  Scheduler.run_allow_deadlock (fun () ->
+  Scheduler.run_allow_deadlock ~timeout:`Default (fun () ->
       let sw1, sw2 = mk_tw_chan () in
       Scheduler.fork (work sw1 1);
       work sw2 2 ())
@@ -41,7 +41,7 @@ let work sw v () =
   Printf.printf "%d %d" x y
 
 let three_way () =
-  Scheduler.run_allow_deadlock (fun () ->
+  Scheduler.run_allow_deadlock ~timeout:`Default (fun () ->
       let sw1, sw2, sw3 = mk_tw_chan () in
       Scheduler.fork (work sw1 1);
       Scheduler.fork (work sw2 2);

--- a/tests/queue_test.ml
+++ b/tests/queue_test.ml
@@ -18,8 +18,8 @@ let num_doms = 4
 let num_items = 300_000
 let items_per_dom = num_items / num_doms
 
-module S = (val Sched_ws.make num_doms ())
-module Reagents = Reagents.Make (S)
+module Scheduler = (val Sched_ws.make num_doms ())
+module Reagents = Reagents.Make (Scheduler)
 
 module type QUEUE = sig
   type 'a t
@@ -85,7 +85,7 @@ module Test (Q : QUEUE) = struct
       else match Q.pop q with None -> consume i | Some _ -> consume (i + 1)
     in
     for i = 1 to num_doms - 1 do
-      S.fork (fun () ->
+      Scheduler.fork (fun () ->
           if i mod 2 == 0 then produce items_per_domain else consume 0;
           Reagents.run (CDL.count_down b) ())
     done;
@@ -144,4 +144,4 @@ let main () =
     sd
     (float_of_int num_items /. m)
 
-let () = S.run main
+let () = Scheduler.run ~timeout:`Default main

--- a/tests/reagent_queue_test.ml
+++ b/tests/reagent_queue_test.ml
@@ -18,8 +18,8 @@ let num_doms = 2
 let num_items = 300_000
 let items_per_dom = num_items / num_doms
 
-module S = (val Sched_ws.make num_doms ())
-module Reagents = Reagents.Make (S)
+module Scheduler = (val Sched_ws.make num_doms ())
+module Reagents = Reagents.Make (Scheduler)
 open Reagents
 
 module type QUEUE = sig
@@ -86,7 +86,7 @@ module Test (Q : QUEUE) = struct
       else match Q.pop q with None -> consume i | Some _ -> consume (i + 1)
     in
     for _ = 1 to num_doms - 1 do
-      S.fork (fun () ->
+      Scheduler.fork (fun () ->
           produce items_per_domain;
           consume 0;
           run (CDL.count_down b) ())
@@ -103,4 +103,4 @@ let main () =
   Printf.printf "Reagent Lockfree.MSQueue: mean = %f, sd = %f tp=%f\n%!" m sd
     (float_of_int num_items /. m)
 
-let () = S.run main
+let () = Scheduler.run ~timeout:`Default main

--- a/tests/rec_test.ml
+++ b/tests/rec_test.ml
@@ -12,7 +12,7 @@ let rec lock_and_call l i =
   assert (run (RLock.rel l) ())
 
 let test1 () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let l = RLock.create () in
 
       Scheduler.fork (fun () ->

--- a/tests/ref_channel.ml
+++ b/tests/ref_channel.ml
@@ -32,7 +32,7 @@ open Reagents
 module Channel = Ref_channel (Reagents)
 
 let chan_send_receive () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let c = Channel.mk_chan () in
       Scheduler.fork (fun () -> Printf.printf "%d\n" (run (Channel.recv c) ()));
       run (Channel.send c) 10)

--- a/tests/ref_test.ml
+++ b/tests/ref_test.ml
@@ -19,14 +19,14 @@ module Reagents = Reagents.Make (Scheduler)
 open Reagents
 
 let update () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let r = Ref.mk_ref 0 in
       let foo ov () = if ov = 0 then None else Some (2, ()) in
       Scheduler.fork (fun () -> run (Ref.upd r foo) ());
       run (Ref.cas r 0 1) ())
 
 let update_monadic () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let r = Ref.mk_ref 2 in
       let test2_rg =
         Ref.read r >>= fun i -> if i <> 3 then never else constant ()

--- a/tests/sat.ml
+++ b/tests/sat.ml
@@ -23,7 +23,7 @@ let rec join acc = function
 let join l = join [] l
 
 let test1 () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let r =
         join (make [] n) >>= fun l ->
         (* instead of l = answer, assume `eval_formula l formula` where

--- a/tests/sched_ws.ml
+++ b/tests/sched_ws.ml
@@ -177,7 +177,7 @@ end) : S = struct
           let difference =
             match timeout with
             | `Seconds difference -> difference
-            | `Default -> 300.
+            | `Default -> 30. *. 60.
           in
           Gc.create_alarm (fun () ->
               let current_time = Unix.gettimeofday () in

--- a/tests/sched_ws.ml
+++ b/tests/sched_ws.ml
@@ -177,7 +177,7 @@ end) : S = struct
           let difference =
             match timeout with
             | `Seconds difference -> difference
-            | `Default -> 120.
+            | `Default -> 300.
           in
           Gc.create_alarm (fun () ->
               let current_time = Unix.gettimeofday () in

--- a/tests/sched_ws.ml
+++ b/tests/sched_ws.ml
@@ -177,7 +177,7 @@ end) : S = struct
           let difference =
             match timeout with
             | `Seconds difference -> difference
-            | `Default -> 30.
+            | `Default -> 120.
           in
           Gc.create_alarm (fun () ->
               let current_time = Unix.gettimeofday () in

--- a/tests/sched_ws.ml
+++ b/tests/sched_ws.ml
@@ -174,10 +174,10 @@ end) : S = struct
         (fun timeout ->
           Printexc.record_backtrace true;
           let start_time = Unix.gettimeofday () in
-          let difference = 
-            match timeout with 
-            | `Seconds difference -> difference 
-            | `Default -> 30. 
+          let difference =
+            match timeout with
+            | `Seconds difference -> difference
+            | `Default -> 30.
           in
           Gc.create_alarm (fun () ->
               let current_time = Unix.gettimeofday () in
@@ -191,7 +191,6 @@ end) : S = struct
         f ());
 
     Option.iter Gc.delete_alarm timeout_alarm
-
 
   let run_allow_deadlock ?timeout f =
     match run ?timeout f with exception All_domains_idle -> () | _ -> ()

--- a/tests/stack_test.ml
+++ b/tests/stack_test.ml
@@ -26,8 +26,8 @@ let () =
 let items_per_dom = num_items / num_doms
 let () = Printf.printf "items_per_domain = %d\n%!" items_per_dom
 
-module S = (val Sched_ws.make num_doms ())
-module Reagents = Reagents.Make (S)
+module Scheduler = (val Sched_ws.make num_doms ())
+module Reagents = Reagents.Make (Scheduler)
 open Reagents
 
 module type STACK = sig
@@ -95,7 +95,7 @@ module Test (Q : STACK) = struct
       else match Q.pop q with None -> consume i | Some _ -> consume (i + 1)
     in
     for i = 0 to num_doms - 1 do
-      S.fork (fun () ->
+      Scheduler.fork (fun () ->
           if i mod 2 == 0 then produce items_per_domain else consume 0;
           run (CDL.count_down b) ())
     done;
@@ -158,4 +158,4 @@ let main () =
   Printf.printf "Channel-based stack: mean = %f, sd = %f tp=%f\n%!" m sd
     (float_of_int num_items /. m)
 
-let () = S.run main
+let () = Scheduler.run ~timeout:`Default main

--- a/tests/stack_test_compose.ml
+++ b/tests/stack_test_compose.ml
@@ -19,8 +19,8 @@ let num_items = 1_000_000
 let items_per_dom = num_items / 2
 let () = Printf.printf "items_per_domain = %d\n%!" @@ items_per_dom
 
-module S = (val Sched_ws.make 4 ())
-module Reagents = Reagents.Make (S)
+module Scheduler = (val Sched_ws.make 4 ())
+module Reagents = Reagents.Make (Scheduler)
 open Reagents
 
 module Benchmark = struct
@@ -75,10 +75,10 @@ module Test (Stack : STACK) = struct
           let _ = Stack.pop q1 q2 in
           consume (i - 1)
     in
-    S.fork (fun () ->
+    Scheduler.fork (fun () ->
         produce 1 q1 items_per_domain;
         run (CDL.count_down b) ());
-    S.fork (fun () ->
+    Scheduler.fork (fun () ->
         produce 2 q2 items_per_domain;
         run (CDL.count_down b) ());
     consume items_per_domain;
@@ -148,4 +148,4 @@ let main () =
 
   ()
 
-let () = S.run main
+let () = Scheduler.run ~timeout:`Default main

--- a/tests/swap_test.ml
+++ b/tests/swap_test.ml
@@ -20,7 +20,7 @@ open Reagents
 open Reagents.Channel
 
 let two_chan_passthrough () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let ep1, ep2 = mk_chan () in
       let fp1, fp2 = mk_chan () in
       Scheduler.fork (fun () -> assert (run (swap fp1 >>> swap ep1) 1 == 2));
@@ -28,21 +28,21 @@ let two_chan_passthrough () =
       assert (run (swap ep2) 2 == 0))
 
 let one_chan_loopback () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let ep1, ep2 = mk_chan () in
       Scheduler.fork (fun () -> assert (run (swap ep1 >>> swap ep1) 1 == 0));
       Scheduler.fork (fun () -> assert (run (swap ep2) 0 == 2));
       assert (run (swap ep2) 2 == 1))
 
 let chan_with_choice () =
-  Scheduler.run (fun () ->
+  Scheduler.run ~timeout:`Default (fun () ->
       let ep1, ep2 = mk_chan () in
       Scheduler.fork (fun () -> assert (run (swap ep1 <+> swap ep2) 0 == 1));
       assert (run (swap ep2) 1 == 0))
 
 let chan_swap_on_overlapping_locs () =
   (* Reagents are not as powerful as communicating transactions. *)
-  Scheduler.run_allow_deadlock (fun () ->
+  Scheduler.run_allow_deadlock ~timeout:`Default (fun () ->
       let ep1, ep2 = mk_chan () in
       Scheduler.fork (fun () ->
           Printf.printf "%d\n%!" (run (swap ep1 >>> swap ep1) 0));
@@ -50,7 +50,7 @@ let chan_swap_on_overlapping_locs () =
 
 let ref_upd_on_overlapping_locs () =
   (* This test should not succeed; expecting kcas failure *)
-  Scheduler.run_allow_deadlock (fun () ->
+  Scheduler.run_allow_deadlock ~timeout:`Default (fun () ->
       let a, b = mk_chan () in
       let r = Ref.mk_ref 0 in
       Scheduler.fork (fun () ->


### PR DESCRIPTION
The CI is occasionally hanging and failing after a 60m wait. I suspect that one of the tests deadlocks. Let's add timeouts to all of them, which is nice to have anyway. 